### PR TITLE
Comment out dummy node

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -31,12 +31,12 @@ exports.createNodesFromEntities = ({entities, entityType, schemaType, devRefresh
   // Add entity type to each entity
   entities = createEntityType(entityType, entities)
 
-  const dummyEntity = {
-    id: 'dummy',
-    __type: entityType,
-    ...schemaType
-  }
-  entities.push(dummyEntity)
+//   const dummyEntity = {
+//     id: 'dummy',
+//     __type: entityType,
+//     ...schemaType
+//   }
+//   entities.push(dummyEntity)
 
   // warn if setting `enableDevRefresh` but not `ENABLE_GATSBY_REFRESH_ENDPOINT`
   if (devRefresh && !enableRefreshEndpoint) {


### PR DESCRIPTION
This dummy node 'pollutes' the data in graphql which requires to filter it out when actually querying the data.
No idea what problem it solves but with some testing, removing it didn't cause any issues for our use case (where we did have data).